### PR TITLE
GitHub Actions: Build matrix for different Java versions

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,0 @@
-cache:
-  - C:\Users\appveyor\.m2
-
-build_script:
-  - .\mvnw verify

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 9, 10]
+        java: [7, 8, 9, 10]
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, windows-2019]
+        os: [ubuntu-18.04, macOS-10.15, windows-2019]
         java: [6, 7, 8, 9, 10]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,14 @@ jobs:
   build:
     strategy:
       fail-fast: false
+      matrix:
+        java: [8, 9]
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: ${{ matrix.java }}
     - name: Java version
       run: java -version && javac -version
     - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [7, 8, 9, 10]
+        java: [6, 7, 8, 9, 10]
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-18.04, windows-2019]
         java: [6, 7, 8, 9, 10]
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 9]
+        java: [8, 9, 10]
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,5 +16,7 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 8
+    - name: Java version
+      run: java -version && javac -version
     - name: Build
       run: ./mvnw verify -Ppitest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macOS-10.15, windows-2019]
+        os: [ubuntu-18.04, windows-2019]
         java: [6, 7, 8, 9, 10]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,4 +21,4 @@ jobs:
     - name: Java version
       run: java -version && javac -version
     - name: Build
-      run: ./mvnw verify -Ppitest
+      run: ./mvnw verify -Ppitest -s .mvn/settings.xml

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,34 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+	<profiles>
+		<profile>
+			<activation>
+				<jdk>1.6</jdk>
+			</activation>
+			<repositories>
+				<repository>
+					<snapshots>
+						<enabled>false</enabled>
+					</snapshots>
+					<id>central</id>
+					<name>Central Repository</name>
+					<url>http://insecure.repo1.maven.org/maven2</url>
+				</repository>
+			</repositories>
+			<pluginRepositories>
+				<pluginRepository>
+					<releases>
+						<updatePolicy>never</updatePolicy>
+					</releases>
+					<snapshots>
+						<enabled>false</enabled>
+					</snapshots>
+					<id>central</id>
+					<name>Central Repository</name>
+					<url>http://insecure.repo1.maven.org/maven2</url>
+				</pluginRepository>
+			</pluginRepositories>
+		</profile>
+	</profiles>
+</settings>

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.2.5/apache-maven-3.2.5-bin.zip
+distributionUrl=http://insecure.repo1.maven.org/maven2/org/apache/maven/apache-maven/3.2.5/apache-maven-3.2.5-bin.zip

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [ASM](http://asm.ow2.org/) powered by definitions/uses analysis
 
-[![Build Status](https://img.shields.io/travis/saeg/asm-defuse.svg?style=flat-square)](https://travis-ci.org/saeg/asm-defuse)
 [![Coverage Status](https://img.shields.io/coveralls/saeg/asm-defuse.svg?style=flat-square)](https://coveralls.io/r/saeg/asm-defuse?branch=master)
 [![Maven Central](https://img.shields.io/maven-central/v/br.usp.each.saeg/asm-defuse.svg?style=flat-square)](https://maven-badges.herokuapp.com/maven-central/br.usp.each.saeg/asm-defuse)
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,6 @@
 					</properties>
 					<excludes>
 						<exclude>pom.xml</exclude>
-						<exclude>.appveyor.yml</exclude>
 						<exclude>.github/**</exclude>
 						<exclude>mvnw</exclude>
 						<exclude>mvnw.cmd</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
 	</issueManagement>
 
 	<ciManagement>
-		<system>Travis CI</system>
-		<url>https://travis-ci.org/saeg/asm-defuse</url>
+		<system>GitHub Actions</system>
+		<url>https://github.com/saeg/asm-defuse/actions</url>
 	</ciManagement>
 
 	<developers>


### PR DESCRIPTION
**Building with different Java and OS versions in GitHub Actions CI**

Commit 31b637a761d49b4341f3d999bb8c943a275c111e removed Travis CI build because I was facing several problems with it. GitHub Actions was enabled on commit bf642055da9981273b1abfe4b1bfa409bdad5f8f.

This PR enables GitHub Actions build for different Java versions. Building with Java 6, 7, 8, 9 and 10 on Linux `ubuntu-18.04` and Windows `windows-2019`.

I also tried to run the build on macOS `macos-10.15` but GitHub Actions failed miserably.
see: https://github.com/saeg/asm-defuse/actions/runs/108257529
see: https://github.com/saeg/asm-defuse/actions/runs/108270535

This PR also removes any reference to Travis CI and AppVeyor CI since we are using GitHub Actions for both Linux and Windows builds.