### PR TITLE
Build with older Java 7 (< 1.7.0_131-b31)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, windows-2019]
-        java: [6, 7, 8, 9, 10]
+        java: [6, 7, 7.0.121, 8, 9, 10]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2


### PR DESCRIPTION
Java 7 supports TLS 1.2 but it is disabled by default in versions before 1.7.0_131-b31.