### PR TITLE
Default Maven wrapper user settings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,4 +22,4 @@ jobs:
     - name: Java version
       run: java -version && javac -version
     - name: Build
-      run: ./mvnw verify -Ppitest -s .mvn/settings.xml
+      run: ./mvnw verify -Ppitest

--- a/mvnw
+++ b/mvnw
@@ -224,4 +224,4 @@ exec "$JAVACMD" \
   $MAVEN_OPTS \
   -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
   "-Dmaven.home=${M2_HOME}" "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
-  ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"
+  ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@" -s "$MAVEN_PROJECTBASEDIR/.mvn/settings.xml"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -118,8 +118,9 @@ SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 
 set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+set USER_SETTINGS="%MAVEN_PROJECTBASEDIR%\.mvn\settings.xml"
 
-%MAVEN_JAVA_EXE% %JVM_CONFIG_MAVEN_PROPS% %MAVEN_OPTS% %MAVEN_DEBUG_OPTS% -classpath %WRAPPER_JAR% "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
+%MAVEN_JAVA_EXE% %JVM_CONFIG_MAVEN_PROPS% %MAVEN_OPTS% %MAVEN_DEBUG_OPTS% -classpath %WRAPPER_JAR% "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %* -s %USER_SETTINGS%
 if ERRORLEVEL 1 goto error
 goto end
 


### PR DESCRIPTION
This is to avoid manually set the Maven option of the alternate path for the user settings file (`-s` or `--settings`).

The Maven wrapper scripts will set this option automatically to file `.mvn/settings.xml`.

The build will fail if this file does not existis.