### PR TITLE
Remove Coveralls integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [ASM](http://asm.ow2.org/) powered by definitions/uses analysis
 
-[![Coverage Status](https://img.shields.io/coveralls/saeg/asm-defuse.svg?style=flat-square)](https://coveralls.io/r/saeg/asm-defuse?branch=master)
 [![Maven Central](https://img.shields.io/maven-central/v/br.usp.each.saeg/asm-defuse.svg?style=flat-square)](https://maven-badges.herokuapp.com/maven-central/br.usp.each.saeg/asm-defuse)
 
 ASM-DefUse extends [ASM](http://asm.ow2.org/) analysis API with control- and data-flow algorithms for definition/uses analysis.

--- a/pom.xml
+++ b/pom.xml
@@ -174,11 +174,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.eluder.coveralls</groupId>
-				<artifactId>coveralls-maven-plugin</artifactId>
-				<version>3.2.1</version>
-			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
We are not using Coveralls since we removed Travis integration (31b637a)

Also, coveralls-maven-plugin isn't working with most newer Java versions

Let keep it simple 😄 