### PR TITLE
 Fix GitHub Actions: Conditional build using major Java version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,13 +19,15 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
+    - id: get-major-java-version
+      run: echo "::set-output name=value::$(echo ${{ matrix.java }} | cut -d. -f1)"
     - name: Java version
       run: java -version && javac -version
     - name: Build
-      if: ${{ matrix.java < 16 }}
+      if: ${{ steps.get-major-java-version.outputs.value < 16 }}
       run: ./mvnw verify -Ppitest
     - name: Build
-      if: ${{ matrix.java >= 16 }}
+      if: ${{ steps.get-major-java-version.outputs.value >= 16 }}
       run: ./mvnw verify -Ppitest
       env:
         MAVEN_OPTS: "--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED"


### PR DESCRIPTION
On PR #20 (e7da414) we introduced a conditional build based on the major
version number of Java. But if the version is a string we can't compare
it with a number.

see: https://docs.github.com/en/actions/learn-github-actions/expressions

note: the build for Java 7.0.121 is not running.

This commit extract the major version, that is, the first number before
any dot, so we can use it to compare versions.