### PR TITLE
Update GitHub Actions build to use Linux Ubuntu 20.04 (ubuntu-20.04)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, windows-2019]
+        os: [ubuntu-20.04, windows-2019]
         java: [6, 7, 7.0.121, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
See: https://github.com/saeg/asm-defuse/pull/27#issuecomment-2045732008