### PR TITLE
Update GitHub Actions build to use Linux Ubuntu 22.04 (ubuntu-22.04)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019]
+        os: [ubuntu-22.04, windows-2019]
         java: [6, 7, 7.0.121, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The build using Ubuntu 20.04 is failing with the following error:

```
This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```

Ubuntu 20.04 is deprecated on GitHub Actions.

See: https://github.com/actions/runner-images/issues/11101

This kind of deprecation already happened before.

See: https://github.com/saeg/asm-defuse/pull/28 (#28)

Just updated to the next LTS Ubuntu (22.04).